### PR TITLE
Tidy up "Remote repositories"

### DIFF
--- a/_episodes/l2-02-remote_repositories.md
+++ b/_episodes/l2-02-remote_repositories.md
@@ -20,17 +20,16 @@ keypoints:
 
 ## Remote and local repositories
 
-- The repository you just created in the previous episode is a **remote
-  repository**: it is hosted by a third party hosting system, GitHub in this
-  case.
-- The repository you used in Lesson 1 was a **local repository**: it was just a
-  directory on your hard drive using git for version control.
+- The ``example`` repository you just created is a **remote repository**: it is 
+  hosted by a third party hosting system - GitHub in this case.
+- The ``recipe`` repository you created earlier was a **local repository**: it 
+  was just a directory on your hard drive using git for version control.
 - Local and remote repositories can be synchronized, so changes are accessible
   by other contributors.
 - **This synchronisation is not automatic**: it has to be done explicitly for
   each branch you want to keep up to date (see **pull** and **push** below ).
 - The default name for a remote repository synchronised with a local one is
-  `origin`.
+  ``origin``.
 
 ### Tracking and upstream
 
@@ -48,13 +47,12 @@ local one out of it or the other way around, the steps are different.
 > ## Configuring a remote repository from a local one
 >
 > In this case, you have a local repository and you want to synchronise it with
-> a new, remote one. Let's create a remote for the `recipe` repository you
-> worked on in Lesson 1. If you have lost your copy of the `recipe` repository
-> you can download a completed copy [here](../code/recipe_with_history.zip):
+> a new, remote one. Let's create a remote for the ``recipe`` repository you
+> worked on earlier.
 >
 > - Create a new repository in GitHub, as in the last episode. Give it a name,
->   description and choose if it should be public or private, but do not add any
->   other file (no README or licence).
+>   description and choose if it should be public or private, but **do not add any
+>   other file** (no README or licence).
 > - You will be offered a few options to populate the remote repository. We are
 >   interested in the third one. You will need to make sure HTTPS is selected
 >   (not SSH) for your personal access token to work.
@@ -70,9 +68,9 @@ local one out of it or the other way around, the steps are different.
 > `https://github.com/ImperialCollegeLondon/introductory_grad_school_git_course.git`
 > In general, it is something like: `https://github.com/USERNAME/REPO_NAME.git`
 >
-> **Mac and Linux users:** You will be asked to provide your GitHub username and password.
+> **macOS and Linux users:** You will be asked to provide your GitHub username and password.
 > Enter your personal access token (PAT) as your password.
-> **Windows users:** You will be presented with a `CredentialHelperSelector` dialog box.
+> **Windows users:** You will be presented with a ``CredentialHelperSelector`` dialog box.
 > Ensure "manager-core" is selected and check the box for "Always use this from now
 > on". Press Select. From the next dialog select "Token" then paste the PAT you saved
 > earlier and press "Sign in". On subsequent interactions with GitHub your credentials
@@ -110,7 +108,7 @@ local one out of it or the other way around, the steps are different.
 > - By default, a local `main` branch will be created tracking the
 >   `origin/main` branch.
 > - You can find some information on the repository using the commands already
->   discussed in Lesson 1, like `git log`.
+>   discussed, like `git log`.
 > ![Effect of cloning a remote repository]({{ site.baseurl }}/fig/clone.png "Effect of cloning a remote repository"){:class="img-responsive"}
 {: .challenge}
 

--- a/_episodes/l2-02-remote_repositories.md
+++ b/_episodes/l2-02-remote_repositories.md
@@ -61,7 +61,7 @@ local one out of it or the other way around, the steps are different.
 >
 > ```bash
 > git remote add origin ADDRESS_OF_YOUR_REMOTE_REPO
-> git push -u origin main
+> git push --set-upstream origin main
 > ```
 >
 > For example, for this course's repository, the address would be:

--- a/_episodes/l2-02-remote_repositories.md
+++ b/_episodes/l2-02-remote_repositories.md
@@ -20,9 +20,9 @@ keypoints:
 
 ## Remote and local repositories
 
-- The ``example`` repository you just created is a **remote repository**: it is 
+- The ``example`` repository you just created is a **remote repository**: it is
   hosted by a third party hosting system - GitHub in this case.
-- The ``recipe`` repository you created earlier was a **local repository**: it 
+- The ``recipe`` repository you created earlier was a **local repository**: it
   was just a directory on your hard drive using git for version control.
 - Local and remote repositories can be synchronized, so changes are accessible
   by other contributors.

--- a/_episodes/l2-02-remote_repositories.md
+++ b/_episodes/l2-02-remote_repositories.md
@@ -12,7 +12,7 @@ objectives:
 - "Use the push command to send changes on the local branch to the remote one."
 - "Use the pull command to update your local branch with the remote one."
 keypoints:
-- "origin is typically the name of the remote repository used by git."
+- "origin is typically the name of the remote repository used by GitHub."
 - "Local and remote repositories are not identical, in general."
 - "Local and remote repositories are not synchronized automatically."
 - "push and pull commands only affect the branch currently checked out."
@@ -119,7 +119,7 @@ local one out of it or the other way around, the steps are different.
  branch to its upstream branch: `git push`.
 - Changes in the staging area will not be synchronized.
 ![Effect of pushing a branch]({{ site.baseurl }}/fig/push.png "Effect of pushing a branch"){:class="img-responsive"}
-- If the upstream branch has changes you do not have in the local branch, the
+- If the upstream branch has changes that you do not have in the local branch, the
  command will fail, requesting you to `pull` those changes first (see below).
 
 > ## Pushing an updated README

--- a/_episodes/l2-02-remote_repositories.md
+++ b/_episodes/l2-02-remote_repositories.md
@@ -57,12 +57,12 @@ local one out of it or the other way around, the steps are different.
 >   interested in the third one. You will need to make sure HTTPS is selected
 >   (not SSH) for your personal access token to work.
 > - Launch a new command line interface and run `cd recipe` to navigate to the
->   directory where you have your local repository - Then execute:
+>   directory where you have your local repository - then execute:
 >
->```bash
->$ git remote add origin ADDRESS_OF_YOUR_REMOTE_REPO
->$ git push -u origin main
->```
+> ```bash
+> git remote add origin ADDRESS_OF_YOUR_REMOTE_REPO
+> git push -u origin main
+> ```
 >
 > For example, for this course's repository, the address would be:
 > `https://github.com/ImperialCollegeLondon/introductory_grad_school_git_course.git`
@@ -98,8 +98,8 @@ local one out of it or the other way around, the steps are different.
 > - Open a new command line interface and execute the commands:
 >
 > ```bash
-> $ git clone ADDRESS_OF_YOUR_REMOTE_REPO
-> $ cd example
+> git clone ADDRESS_OF_YOUR_REMOTE_REPO
+> cd example
 > ```
 >
 > - This will download the remote repository to a new `example` directory, in
@@ -115,7 +115,7 @@ local one out of it or the other way around, the steps are different.
 ## Pushing
 
 - Its basic use is to synchronize **any committed changes** in your current
- branch to its upstream branch: `$ git push`.
+ branch to its upstream branch: `git push`.
 - Changes in the staging area will not be synchronized.
 ![Effect of pushing a branch]({{ site.baseurl }}/fig/push.png "Effect of pushing a branch"){:class="img-responsive"}
 - If the upstream branch has changes you do not have in the local branch, the
@@ -135,9 +135,9 @@ local one out of it or the other way around, the steps are different.
 > > ## Solution
 > >
 > > ```bash
-> > $ git add README.md
-> > $ git commit -m COMMIT_MESSAGE
-> > $ git push
+> > git add README.md
+> > git commit -m COMMIT_MESSAGE
+> > git push
 > > ```
 > >
 > {: .solution}
@@ -179,15 +179,15 @@ local one out of it or the other way around, the steps are different.
 > > ## Solution
 > >
 > > ```bash
-> > $ git fetch
-> > $ git status
+> > git fetch
+> > git status
 > > ```
 > >
 > > This will indicate that the remote branch is ahead of your local branch
 > by 1 commit. Since there are no diverging commits, it is safe to pull.
 > >
 > > ```bash
-> > $ git pull
+> > git pull
 > > ```
 > >
 > {: .solution}

--- a/_episodes/l2-02-remote_repositories.md
+++ b/_episodes/l2-02-remote_repositories.md
@@ -98,6 +98,7 @@ local one out of it or the other way around, the steps are different.
 > - Open a new command line interface and execute the commands:
 >
 > ```bash
+> cd $HOME
 > git clone ADDRESS_OF_YOUR_REMOTE_REPO
 > cd example
 > ```


### PR DESCRIPTION
This PR improves the consistency of the "Remote repositories" episode with the rest of the course, as well as a couple of minor content improvements. 

* References to "Lesson 1", and potentially needing to download `recipe_with_history.zip` are removed, since this all takes place in the same session. 
* `$` prompts are removed from commands, following recent changes made elsewhere.
* `git push -u ...` changed to `git push --set-upstream ...`, as I feel this helps clarify the term "upstream" to students.
* Added a `cd $HOME` before cloning `example` repository, so that they don't try and clone into their existing `recipe` repository.