### PR TITLE
Fix links

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -25,11 +25,11 @@ Under the following terms:
 
 * **Attribution**---You must give appropriate credit (mentioning that
   your work is derived from work that is Copyright © Imperial
-  College and, where practical, linking to
-  https://www.imperial.ac.uk/study/pg/graduate-school/), provide a [link to the
-  license][cc-by-human], and indicate if changes were made. You may do
-  so in any reasonable manner, but not in any way that suggests the
-  licensor endorses you or your use.
+  College London and, where practical, linking to
+  https://www.imperial.ac.uk/students/academic-support/graduate-school/), 
+  provide a [link to the license][cc-by-human], and indicate if changes 
+  were made. You may do so in any reasonable manner, but not in any way 
+  that suggests the licensor endorses you or your use.
 
 **No additional restrictions**---You may not apply legal terms or
 technological measures that legally restrict others from doing

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -26,9 +26,9 @@ Under the following terms:
 * **Attribution**---You must give appropriate credit (mentioning that
   your work is derived from work that is Copyright © Imperial
   College London and, where practical, linking to
-  https://www.imperial.ac.uk/students/academic-support/graduate-school/), 
-  provide a [link to the license][cc-by-human], and indicate if changes 
-  were made. You may do so in any reasonable manner, but not in any way 
+  https://www.imperial.ac.uk/students/academic-support/graduate-school/),
+  provide a [link to the license][cc-by-human], and indicate if changes
+  were made. You may do so in any reasonable manner, but not in any way
   that suggests the licensor endorses you or your use.
 
 **No additional restrictions**---You may not apply legal terms or

--- a/_episodes/l2-01-sharing_your_code.md
+++ b/_episodes/l2-01-sharing_your_code.md
@@ -78,7 +78,7 @@ If you're familiar with SSH keys, you can follow [these instructions][ssh-instru
 >
 {: .challenge}
 
-[pat-instructions]: https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token#creating-a-token
+[pat-instructions]: https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-personal-access-token-classic
 [ssh-instructions]: https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account
 
 ### Private vs public repositories
@@ -176,7 +176,7 @@ See [GitHub Help: Adding a license to a repository][adding-licence]
 > you want a different licence model for your work e.g. commercial.
 {: .callout}
 
-[licence-guidance]: https://www.imperial.ac.uk/enterprise/staff/industry-partnerships-and-commercialisation/commercialisation/intellectual-property-guidance/open-source-software-licences/
+[licence-guidance]: https://www.imperial.ac.uk/admin-services/ict/self-service/research-support/rcs/service-offering/research-software-engineering/legal-information/
 [ip-guidance]: https://www.imperial.ac.uk/research-and-innovation/about-imperial-research/research-integrity/ip/
 
 > ## Open Source software licences

--- a/_episodes/l2-01-sharing_your_code.md
+++ b/_episodes/l2-01-sharing_your_code.md
@@ -176,7 +176,7 @@ See [GitHub Help: Adding a license to a repository][adding-licence]
 > you want a different licence model for your work e.g. commercial.
 {: .callout}
 
-[licence-guidance]: https://www.imperial.ac.uk/admin-services/ict/self-service/research-support/rcs/service-offering/research-software-engineering/legal-information/
+[licence-guidance]: https://imperiallondon.sharepoint.com/:b:/r/sites/ente/Gov/PoliciesandGuidanceforImperialStaff/Imperial_Enterprise_Open%20Source%20Software%20Licences_Aug23.pdf?csf=1&web=1&e=HlaOgx
 [ip-guidance]: https://www.imperial.ac.uk/research-and-innovation/about-imperial-research/research-integrity/ip/
 
 > ## Open Source software licences

--- a/_extras/about.md
+++ b/_extras/about.md
@@ -13,6 +13,6 @@ weekly [RCS clinic][clinic].
 
 {% include links.md %}
 
-[RSE]: https://www.imperial.ac.uk/admin-services/ict/self-service/research-support/rcs/research-software-engineering/
+[RSE]: https://www.imperial.ac.uk/admin-services/ict/self-service/research-support/rcs/service-offering/research-software-engineering/
 [community]: https://www.imperial.ac.uk/computational-methods/rse/
-[clinic]: http://www.imperial.ac.uk/admin-services/ict/self-service/research-support/rcs/support/attend-a-clinic/
+[clinic]: https://www.imperial.ac.uk/admin-services/ict/self-service/research-support/rcs/service-offering/research-software-engineering/code-surgeries/


### PR DESCRIPTION
This PR fixes some broken links/urls throughout the course material.

@dalonsoa - the link to Imperial's guidance on open source software licensing was broken, and I couldn't find an equivalent page, so I provided a link to the related page within the Research Software Engineering webpages. I don't know if this is the best place - perhaps you might know where the old page has moved to?