### PR TITLE
add workflow when creating PAT

### DIFF
--- a/_episodes/l2-01-sharing_your_code.md
+++ b/_episodes/l2-01-sharing_your_code.md
@@ -62,7 +62,7 @@ Set up your free github account:
 Create a Personal Access Token (PAT):
 
 1. In order to access GitHub from the command line, you will need a PAT.
-2. Follow the instructions [here][pat-instructions] to generate one. Ensure that "repo" is ticked.
+2. Follow the instructions [here][pat-instructions] to generate one. Ensure that "repo" and "workflow" are ticked.
 3. Keep the PAT safe - once you navigate away from the page you won't be able to view it again.
    If you lose it, you can always regenerate it.
 


### PR DESCRIPTION
This pull request includes a small update to the instructions for setting up a Personal Access Token (PAT) in the `Set up your free github account` section of the `_episodes/l2-01-sharing_your_code.md` file. The change ensures that users are instructed to tick both "repo" and "workflow" when generating a PAT. 

During the intermediate lesson, some people got this error when adding a workflow to their repo 
```
! [remote rejected] main -> main (refusing to allow a Personal Access Token to create or update workflow `.github/workflows/ci.yml` without `workflow` scope)
``` 

