### PR TITLE
Update remotes key points

### DIFF
--- a/_episodes/l2-02-remote_repositories.md
+++ b/_episodes/l2-02-remote_repositories.md
@@ -13,8 +13,8 @@ objectives:
 - "Use the pull command to update your local branch with the remote one."
 keypoints:
 - "origin is the default name used by GitHub to refer to a remote repository."
-- "Local and remote repositories are not identical, in general."
-- "Local and remote repositories are not synchronized automatically."
+- "Local and remote repositories are not identical, in general, as synchronisation
+  must be performed manually."
 - "push and pull commands only affect the branch currently checked out."
 ---
 

--- a/_episodes/l2-02-remote_repositories.md
+++ b/_episodes/l2-02-remote_repositories.md
@@ -18,7 +18,7 @@ keypoints:
 - "`git fetch`, followed by `git status`, shows whether there are any changes to
   synchronise."
 - "`git pull` brings changes in the upstream branch to the local branch."
-- "`git push` synchronises any committed changes in your local branch with the 
+- "`git push` synchronises any committed changes in your local branch with the
   upstream branch."
 - "push and pull commands only affect the branch currently checked out."
 ---

--- a/_episodes/l2-02-remote_repositories.md
+++ b/_episodes/l2-02-remote_repositories.md
@@ -12,7 +12,7 @@ objectives:
 - "Use the push command to send changes on the local branch to the remote one."
 - "Use the pull command to update your local branch with the remote one."
 keypoints:
-- "origin is typically the name of the remote repository used by GitHub."
+- "origin is the default name used by GitHub to refer to a remote repository."
 - "Local and remote repositories are not identical, in general."
 - "Local and remote repositories are not synchronized automatically."
 - "push and pull commands only affect the branch currently checked out."

--- a/_episodes/l2-02-remote_repositories.md
+++ b/_episodes/l2-02-remote_repositories.md
@@ -15,6 +15,11 @@ keypoints:
 - "origin is the default name used by GitHub to refer to a remote repository."
 - "Local and remote repositories are not identical, in general, as synchronisation
   must be performed manually."
+- "`git fetch`, followed by `git status`, shows whether there are any changes to
+  synchronise."
+- "`git pull` brings changes in the upstream branch to the local branch."
+- "`git push` synchronises any committed changes in your local branch with the 
+  upstream branch."
 - "push and pull commands only affect the branch currently checked out."
 ---
 

--- a/_episodes/l2-02-remote_repositories.md
+++ b/_episodes/l2-02-remote_repositories.md
@@ -12,7 +12,7 @@ objectives:
 - "Use the push command to send changes on the local branch to the remote one."
 - "Use the pull command to update your local branch with the remote one."
 keypoints:
-- "origin is the default name used by GitHub to refer to a remote repository."
+- "origin is the default name used by Git to refer to a remote repository."
 - "Local and remote repositories are not identical, in general, as synchronisation
   must be performed manually."
 - "`git fetch`, followed by `git status`, shows whether there are any changes to


### PR DESCRIPTION
This PR contains a proposed improvement to the key points section of the remote repositories lesson.

* Clarified the meaning of `origin`
* Combined the two points about synchronising local and remote
* Added points to summarise `fetch`, `pull` and `push` commands

Closes #71 